### PR TITLE
update composer description: "ZF2" -> "Zend Framework"

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "zendframework/skeleton-application",
-    "description": "Skeleton Application for ZF2",
+    "description": "Skeleton Application for Zend Framework",
     "license": "BSD-3-Clause",
     "keywords": [
         "framework",


### PR DESCRIPTION
old composer.json's description still using "ZF2" wording, I updated to "Zend Framework"